### PR TITLE
fix: iframe 缩放改用 CSS zoom，消除非整数倍缩放导致的整页模糊

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -649,7 +649,8 @@ function buildIframeHtml(url, scale) {
   const origin = target.origin; // 形如 http://127.0.0.1:3080 或 https://xxxx.example.com
   const nonce = makeNonce();
   const s = Number.isFinite(scale) ? Math.min(2, Math.max(0.5, scale)) : 1;
-  const pct = (100 / s).toFixed(4);
+  // 用 CSS zoom 缩放（重新布局、按设备分辨率渲染，任意字号下清晰），
+  // 不用 transform:scale（渲染后栅格化缩放，非整数倍缩放时整页模糊）。
   return `<!DOCTYPE html>
 <html lang="zh-CN">
 <head>
@@ -659,7 +660,7 @@ function buildIframeHtml(url, scale) {
 </head>
 <body style="margin:0;padding:0;width:100vw;height:100vh;overflow:hidden;background:var(--vscode-editor-background);">
 <iframe id="dsh-frame" src="${escapeHtml(url)}"
-        style="width:${pct}%;height:${pct}%;border:none;display:block;transform:scale(${s});transform-origin:0 0;"
+        style="width:100%;height:100%;border:none;display:block;zoom:${s};"
         allow="clipboard-read; clipboard-write; autoplay"></iframe>
 <script nonce="${nonce}">
 (function () {
@@ -672,10 +673,7 @@ function buildIframeHtml(url, scale) {
     n = Math.min(2, Math.max(0.5, n));
     if (n === current) return;
     current = n;
-    var pct = (100 / n).toFixed(4) + '%';
-    frame.style.transform = 'scale(' + n + ')';
-    frame.style.width = pct;
-    frame.style.height = pct;
+    frame.style.zoom = String(n);
   }
   window.addEventListener('message', function (event) {
     var data = event.data;


### PR DESCRIPTION
## 问题

`editor.fontSize` 不等于 16 时（如 14 → 0.875、18 → 1.125），DSH 界面整页模糊（文字、圆角、滚动条边缘发虚），面板字号越大/越小越明显。

## 根因

`buildIframeHtml` 用 `transform: scale(s)` + `width/height: (100/s)%` 对 iframe 做镜像缩放。CSS transform 缩放是**渲染后栅格化缩放**：页面先在 webview 的 DPR=1 表面渲染，再被 GPU 按 `s` 缩放。`s` 是非整数倍（editor.fontSize/16 几乎总是非整数）时，栅格化结果被非整数倍放大/缩小，整个界面（包括自绘滚动条）全部发虚。

## 修复

改用 CSS `zoom: s`，去掉 `transform`/`transform-origin` 和宽度百分比镜像：

- `zoom` 在 Chromium 中是**重新布局**而非后缩放：内容直接按目标比例在设备分辨率下重排渲染，任意非整数倍都清晰；
- VS Code 自身的 webview 缩放（`window.zoomLevel`）就是用 CSS zoom 实现，机制一致；
- 动态缩放脚本（`dsh-font-scale` 消息）同步改为只设 `frame.style.zoom`，不再改 transform 与宽高。

改动仅 `extension.js` 一处，两段（初始 HTML + apply 函数），`getFontScale` 算法不变，0.5–2 倍夹取不变。

## 验证

- `node --check extension.js` 通过；
- 本机 0.8.33 热补丁实测：editor.fontSize = 14 / 16 / 18 下界面均清晰，字号跟随正常，任务面板等自绘滚动条内容同样锐利。
